### PR TITLE
Require HTTP::Server::PSGI before modifying setup_listener

### DIFF
--- a/lib/WWW/Mechanize/PhantomJS/Catalyst.pm
+++ b/lib/WWW/Mechanize/PhantomJS/Catalyst.pm
@@ -88,6 +88,7 @@ sub start_catalyst_server {
     else {
         require Catalyst::ScriptRunner;
         require Catalyst::Script::Server;
+        require HTTP::Server::PSGI;
         
         my $css_pla = \&Catalyst::Script::Server::_plack_loader_args;
         my $new_css_pla = sub {


### PR DESCRIPTION
If HTTP::Server::PSGI was not loaded before modifying HTTP::Server::PSGI::setup_listener the error.
'Subroutine setup_listener redefined at /usr/share/perl5/vendor_perl/HTTP/Server/PSGI.pm' will occur
